### PR TITLE
update broken Learn Guide link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Learn best practices for Terraform as your organization grows. Split a Dev & Prod environment and compose shared modules.
 
-Follow along with the [Learn guide](https://learn.hashicorp.com/terraform/modules/code-org-envs) at HashiCorp Learn.
+Follow along with the [Learn guide](https://learn.hashicorp.com/tutorials/terraform/organize-configuration) at HashiCorp Learn.


### PR DESCRIPTION
The link in the README file is dead, I've updated it to the link that I _believe_ to be to correct. If it's not correct then feel free to correct it! Didn't seem worth opening an issue for it when the fix could be this simple.